### PR TITLE
added optional `extends` param to MO

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,10 @@ Test::Core implements the following mocking functions using [Test::MockModule](h
 
 - `MO(%mocks)`
 
-        # Takes an optional "isa" for extending existing objects
+        # Takes an optional "extends" for extending existing objects
         my $mock = MO(
-            isa => 'DateTime',
-            now => sub { DateTime->now->add(days => 3) },
+            extends => 'DateTime',
+            now     => sub { DateTime->now->add(days => 3) },
         );
 
 # BUGS

--- a/lib/Test/Core.pm
+++ b/lib/Test/Core.pm
@@ -32,7 +32,7 @@ sub mock_module {
 
 sub mock_object {
     my (%mocks) = @_;
-    my $isa         = delete $mocks{isa};
+    my $isa         = delete $mocks{isa} || delete $mocks{extends};
     my $mock_object = $isa
         ? Test::MockObject::Extends->new($isa)
         : Test::MockObject->new;
@@ -270,10 +270,10 @@ Test::Core implements the following mocking functions using L<Test::MockModule>,
 
 =item C<< MO(%mocks) >>
 
-    # Takes an optional "isa" for extending existing objects
+    # Takes an optional "extends" for extending existing objects
     my $mock = MO(
-        isa => 'DateTime',
-        now => sub { DateTime->now->add(days => 3) },
+        extends => 'DateTime',
+        now     => sub { DateTime->now->add(days => 3) },
     );
 
 =back

--- a/t/04-mocking.t
+++ b/t/04-mocking.t
@@ -19,4 +19,9 @@ is $mock_dt->year => '1776';
 ok $mock_dt->isa('DateTime');
 ok !$mock_dt->isa('Test::MockObject');
 
+$mock_dt = MO(extends => DateTime->now, year => 1776);
+is $mock_dt->year => '1776';
+ok $mock_dt->isa('DateTime');
+ok !$mock_dt->isa('Test::MockObject');
+
 done_testing;


### PR DESCRIPTION
Using this module was confusing to me at first because `isa` means
something else in the context of Test::MockObject. I think `extends` is
more aligned with the T::M and T::M::E interfaces and so is less
surprising to people who are used to those.
